### PR TITLE
Storage reformat

### DIFF
--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -33,7 +33,7 @@ pub struct Chunk {
 ///
 /// - Filesystem errors
 /// - Invalid manifests
-pub fn verify_all_chunks(repo_path: &Path) -> anyhow::Result<()> {
+pub fn verify_all_chunks(repo_path: &Path, chunk_store_path: &Path) -> anyhow::Result<()> {
     let repo_manifest = read_manifest(repo_path)?;
     let mut all_chunks = HashSet::new();
 
@@ -43,7 +43,6 @@ pub fn verify_all_chunks(repo_path: &Path) -> anyhow::Result<()> {
         }
     }
 
-    let chunk_store_path = repo_path.join("chunks");
     let mut verified = 0;
     let mut failed = 0;
 

--- a/src/chunks/utils.rs
+++ b/src/chunks/utils.rs
@@ -1,119 +1,125 @@
-// UNSAFE DURING CHUNK STORE MIGRATION
+use anyhow::Result;
+use std::{collections::HashSet, fs, path::Path};
 
-// use anyhow::Result;
-// use std::{collections::HashSet, fs, path::Path};
+use crate::{
+    chunks::{Chunk, get_chunk_filename},
+    repo::{get_all_installed_packages, get_all_packages},
+};
 
-// use crate::{
-//     chunks::{Chunk, get_chunk_filename},
-//     repo::{get_all_installed_packages, get_all_packages},
-// };
+/// Removes chunks that aren't actually used by any packages in the Repository
+/// This is most useful for remote Repository administrators.
+///
+/// # Errors
+///
+/// - Filesystem errors (Permissions most likely)
+/// - Repository doesn't exist
+pub fn clean_unused(repos_path: &Path, chunk_store_path: &Path) -> Result<()> {
+    let mut chunks: Vec<Chunk> = Vec::new();
 
-// /// Removes chunks that aren't actually used by any packages in the Repository
-// /// This is most useful for remote Repository administrators.
-// ///
-// /// # Errors
-// ///
-// /// - Filesystem errors (Permissions most likely)
-// /// - Repository doesn't exist
-// pub fn clean_unused(repo_path: &Path) -> Result<()> {
-//     let packages = get_all_packages(repo_path)?;
-//     let mut chunks: Vec<Chunk> = Vec::new();
+    for entry in repos_path.read_dir()? {
+        let repo_path = entry?.path();
+        let packages = get_all_packages(&repo_path)?;
 
-//     for package in packages {
-//         for chunk in package.chunks.clone() {
-//             chunks.push(chunk);
-//         }
-//     }
+        for package in packages {
+            for chunk in package.chunks.clone() {
+                chunks.push(chunk);
+            }
+        }
+    }
 
-//     clean(&repo_path.join("chunks"), &chunks)
-// }
+    clean(chunk_store_path, &chunks)
+}
 
-// /// Removes chunks that are actually used by any packages in the Repository, but aren't installed
-// /// This is most useful for end users.
-// ///
-// /// # Errors
-// ///
-// /// - Filesystem errors (Permissions most likely)
-// /// - Repository doesn't exist
-// pub fn clean_used(repo_path: &Path) -> Result<()> {
-//     let packages = get_all_installed_packages(repo_path)?;
-//     let mut chunks: Vec<Chunk> = Vec::new();
+/// Removes chunks that are actually used by any packages in the Repository, but aren't installed
+/// This is most useful for end users.
+///
+/// # Errors
+///
+/// - Filesystem errors (Permissions most likely)
+/// - Repository doesn't exist
+pub fn clean_used(repos_path: &Path, chunk_store_path: &Path) -> Result<()> {
+    let mut chunks: Vec<Chunk> = Vec::new();
 
-//     for package in packages {
-//         for chunk in package.chunks.clone() {
-//             chunks.push(chunk);
-//         }
-//     }
+    for entry in repos_path.read_dir()? {
+        let repo_path = entry?.path();
+        let packages = get_all_installed_packages(&repo_path)?;
 
-//     clean(&repo_path.join("chunks"), &chunks)
-// }
+        for package in packages {
+            for chunk in package.chunks.clone() {
+                chunks.push(chunk);
+            }
+        }
+    }
 
-// /// Cleans a `chunk_store` of unused chunks, using the whitelist `allowed_chunks`
-// pub fn clean(chunk_store_path: &Path, allowed_chunks: &[Chunk]) -> Result<()> {
-//     let allowed: HashSet<String> = allowed_chunks
-//         .iter()
-//         .map(|c| get_chunk_filename(&c.hash, c.permissions))
-//         .collect();
+    clean(chunk_store_path, &chunks)
+}
 
-//     for entry in fs::read_dir(chunk_store_path)? {
-//         let entry = entry?;
-//         let file_name = entry.file_name();
-//         let Some(file_name_str) = file_name.to_str() else {
-//             continue;
-//         };
+/// Cleans a `chunk_store` of unused chunks, using the whitelist `allowed_chunks`
+fn clean(chunk_store_path: &Path, allowed_chunks: &[Chunk]) -> Result<()> {
+    let allowed: HashSet<String> = allowed_chunks
+        .iter()
+        .map(|c| get_chunk_filename(&c.hash, c.permissions))
+        .collect();
 
-//         if !allowed.contains(file_name_str) {
-//             fs::remove_file(entry.path())?;
-//         }
-//     }
+    for entry in fs::read_dir(chunk_store_path)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(file_name_str) = file_name.to_str() else {
+            continue;
+        };
 
-//     Ok(())
-// }
+        if !allowed.contains(file_name_str) {
+            fs::remove_file(entry.path())?;
+        }
+    }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use std::fs;
-//     use temp_dir::TempDir;
+    Ok(())
+}
 
-//     #[test]
-//     fn test_clean() -> Result<()> {
-//         let temp_dir = TempDir::new()?;
-//         let chunk_store_path = temp_dir.path();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use temp_dir::TempDir;
 
-//         // Create allowed chunks
-//         let allowed_chunks = vec![
-//             Chunk {
-//                 path: std::path::PathBuf::from("file1"),
-//                 hash: "hash1".to_string(),
-//                 permissions: 0o644,
-//                 size: 1,
-//             },
-//             Chunk {
-//                 path: std::path::PathBuf::from("file2"),
-//                 hash: "hash2".to_string(),
-//                 permissions: 0o644,
-//                 size: 1,
-//             },
-//         ];
+    #[test]
+    fn test_clean() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let chunk_store_path = temp_dir.path();
 
-//         // Create chunk files with correct names
-//         let chunk1_name = get_chunk_filename("hash1", 0o644);
-//         let chunk2_name = get_chunk_filename("hash2", 0o644);
-//         let chunk3_name = get_chunk_filename("hash3", 0o644);
+        // Create allowed chunks
+        let allowed_chunks = vec![
+            Chunk {
+                path: std::path::PathBuf::from("file1"),
+                hash: "hash1".to_string(),
+                permissions: 0o644,
+                size: 1,
+            },
+            Chunk {
+                path: std::path::PathBuf::from("file2"),
+                hash: "hash2".to_string(),
+                permissions: 0o644,
+                size: 1,
+            },
+        ];
 
-//         fs::write(chunk_store_path.join(&chunk1_name), "data1")?;
-//         fs::write(chunk_store_path.join(&chunk2_name), "data2")?;
-//         fs::write(chunk_store_path.join(&chunk3_name), "data3")?;
+        // Create chunk files with correct names
+        let chunk1_name = get_chunk_filename("hash1", 0o644);
+        let chunk2_name = get_chunk_filename("hash2", 0o644);
+        let chunk3_name = get_chunk_filename("hash3", 0o644);
 
-//         // Clean
-//         clean(chunk_store_path, &allowed_chunks)?;
+        fs::write(chunk_store_path.join(&chunk1_name), "data1")?;
+        fs::write(chunk_store_path.join(&chunk2_name), "data2")?;
+        fs::write(chunk_store_path.join(&chunk3_name), "data3")?;
 
-//         // Verify
-//         assert!(chunk_store_path.join(&chunk1_name).exists());
-//         assert!(chunk_store_path.join(&chunk2_name).exists());
-//         assert!(!chunk_store_path.join(&chunk3_name).exists());
+        // Clean
+        clean(chunk_store_path, &allowed_chunks)?;
 
-//         Ok(())
-//     }
-// }
+        // Verify
+        assert!(chunk_store_path.join(&chunk1_name).exists());
+        assert!(chunk_store_path.join(&chunk2_name).exists());
+        assert!(!chunk_store_path.join(&chunk3_name).exists());
+
+        Ok(())
+    }
+}

--- a/src/chunks/utils.rs
+++ b/src/chunks/utils.rs
@@ -1,117 +1,119 @@
-use anyhow::Result;
-use std::{collections::HashSet, fs, path::Path};
+// UNSAFE DURING CHUNK STORE MIGRATION
 
-use crate::{
-    chunks::{Chunk, get_chunk_filename},
-    repo::{get_all_installed_packages, get_all_packages},
-};
+// use anyhow::Result;
+// use std::{collections::HashSet, fs, path::Path};
 
-/// Removes chunks that aren't actually used by any packages in the Repository
-/// This is most useful for remote Repository administrators.
-///
-/// # Errors
-///
-/// - Filesystem errors (Permissions most likely)
-/// - Repository doesn't exist
-pub fn clean_unused(repo_path: &Path) -> Result<()> {
-    let packages = get_all_packages(repo_path)?;
-    let mut chunks: Vec<Chunk> = Vec::new();
+// use crate::{
+//     chunks::{Chunk, get_chunk_filename},
+//     repo::{get_all_installed_packages, get_all_packages},
+// };
 
-    for package in packages {
-        for chunk in package.chunks.clone() {
-            chunks.push(chunk);
-        }
-    }
+// /// Removes chunks that aren't actually used by any packages in the Repository
+// /// This is most useful for remote Repository administrators.
+// ///
+// /// # Errors
+// ///
+// /// - Filesystem errors (Permissions most likely)
+// /// - Repository doesn't exist
+// pub fn clean_unused(repo_path: &Path) -> Result<()> {
+//     let packages = get_all_packages(repo_path)?;
+//     let mut chunks: Vec<Chunk> = Vec::new();
 
-    clean(&repo_path.join("chunks"), &chunks)
-}
+//     for package in packages {
+//         for chunk in package.chunks.clone() {
+//             chunks.push(chunk);
+//         }
+//     }
 
-/// Removes chunks that are actually used by any packages in the Repository, but aren't installed
-/// This is most useful for end users.
-///
-/// # Errors
-///
-/// - Filesystem errors (Permissions most likely)
-/// - Repository doesn't exist
-pub fn clean_used(repo_path: &Path) -> Result<()> {
-    let packages = get_all_installed_packages(repo_path)?;
-    let mut chunks: Vec<Chunk> = Vec::new();
+//     clean(&repo_path.join("chunks"), &chunks)
+// }
 
-    for package in packages {
-        for chunk in package.chunks.clone() {
-            chunks.push(chunk);
-        }
-    }
+// /// Removes chunks that are actually used by any packages in the Repository, but aren't installed
+// /// This is most useful for end users.
+// ///
+// /// # Errors
+// ///
+// /// - Filesystem errors (Permissions most likely)
+// /// - Repository doesn't exist
+// pub fn clean_used(repo_path: &Path) -> Result<()> {
+//     let packages = get_all_installed_packages(repo_path)?;
+//     let mut chunks: Vec<Chunk> = Vec::new();
 
-    clean(&repo_path.join("chunks"), &chunks)
-}
+//     for package in packages {
+//         for chunk in package.chunks.clone() {
+//             chunks.push(chunk);
+//         }
+//     }
 
-/// Cleans a `chunk_store` of unused chunks, using the whitelist `allowed_chunks`
-pub fn clean(chunk_store_path: &Path, allowed_chunks: &[Chunk]) -> Result<()> {
-    let allowed: HashSet<String> = allowed_chunks
-        .iter()
-        .map(|c| get_chunk_filename(&c.hash, c.permissions))
-        .collect();
+//     clean(&repo_path.join("chunks"), &chunks)
+// }
 
-    for entry in fs::read_dir(chunk_store_path)? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let Some(file_name_str) = file_name.to_str() else {
-            continue;
-        };
+// /// Cleans a `chunk_store` of unused chunks, using the whitelist `allowed_chunks`
+// pub fn clean(chunk_store_path: &Path, allowed_chunks: &[Chunk]) -> Result<()> {
+//     let allowed: HashSet<String> = allowed_chunks
+//         .iter()
+//         .map(|c| get_chunk_filename(&c.hash, c.permissions))
+//         .collect();
 
-        if !allowed.contains(file_name_str) {
-            fs::remove_file(entry.path())?;
-        }
-    }
+//     for entry in fs::read_dir(chunk_store_path)? {
+//         let entry = entry?;
+//         let file_name = entry.file_name();
+//         let Some(file_name_str) = file_name.to_str() else {
+//             continue;
+//         };
 
-    Ok(())
-}
+//         if !allowed.contains(file_name_str) {
+//             fs::remove_file(entry.path())?;
+//         }
+//     }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use temp_dir::TempDir;
+//     Ok(())
+// }
 
-    #[test]
-    fn test_clean() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-        let chunk_store_path = temp_dir.path();
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use std::fs;
+//     use temp_dir::TempDir;
 
-        // Create allowed chunks
-        let allowed_chunks = vec![
-            Chunk {
-                path: std::path::PathBuf::from("file1"),
-                hash: "hash1".to_string(),
-                permissions: 0o644,
-                size: 1,
-            },
-            Chunk {
-                path: std::path::PathBuf::from("file2"),
-                hash: "hash2".to_string(),
-                permissions: 0o644,
-                size: 1,
-            },
-        ];
+//     #[test]
+//     fn test_clean() -> Result<()> {
+//         let temp_dir = TempDir::new()?;
+//         let chunk_store_path = temp_dir.path();
 
-        // Create chunk files with correct names
-        let chunk1_name = get_chunk_filename("hash1", 0o644);
-        let chunk2_name = get_chunk_filename("hash2", 0o644);
-        let chunk3_name = get_chunk_filename("hash3", 0o644);
+//         // Create allowed chunks
+//         let allowed_chunks = vec![
+//             Chunk {
+//                 path: std::path::PathBuf::from("file1"),
+//                 hash: "hash1".to_string(),
+//                 permissions: 0o644,
+//                 size: 1,
+//             },
+//             Chunk {
+//                 path: std::path::PathBuf::from("file2"),
+//                 hash: "hash2".to_string(),
+//                 permissions: 0o644,
+//                 size: 1,
+//             },
+//         ];
 
-        fs::write(chunk_store_path.join(&chunk1_name), "data1")?;
-        fs::write(chunk_store_path.join(&chunk2_name), "data2")?;
-        fs::write(chunk_store_path.join(&chunk3_name), "data3")?;
+//         // Create chunk files with correct names
+//         let chunk1_name = get_chunk_filename("hash1", 0o644);
+//         let chunk2_name = get_chunk_filename("hash2", 0o644);
+//         let chunk3_name = get_chunk_filename("hash3", 0o644);
 
-        // Clean
-        clean(chunk_store_path, &allowed_chunks)?;
+//         fs::write(chunk_store_path.join(&chunk1_name), "data1")?;
+//         fs::write(chunk_store_path.join(&chunk2_name), "data2")?;
+//         fs::write(chunk_store_path.join(&chunk3_name), "data3")?;
 
-        // Verify
-        assert!(chunk_store_path.join(&chunk1_name).exists());
-        assert!(chunk_store_path.join(&chunk2_name).exists());
-        assert!(!chunk_store_path.join(&chunk3_name).exists());
+//         // Clean
+//         clean(chunk_store_path, &allowed_chunks)?;
 
-        Ok(())
-    }
-}
+//         // Verify
+//         assert!(chunk_store_path.join(&chunk1_name).exists());
+//         assert!(chunk_store_path.join(&chunk2_name).exists());
+//         assert!(!chunk_store_path.join(&chunk3_name).exists());
+
+//         Ok(())
+//     }
+// }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,21 +20,30 @@ use crate::{
 pub async fn main_commands(
     base_path: &Path,
     quicklaunch_path: &Path,
+    chunk_store_path: &Path,
     command: Command,
 ) -> Result<()> {
     match command {
         Command::Repo { command } => {
-            repo_commands(base_path, command).await?;
+            repo_commands(base_path, chunk_store_path, command).await?;
             update_quicklaunch(base_path, quicklaunch_path)?;
         }
 
         Command::Build {
             build_manifest_path,
             repo_name,
-        } => build_cmd(base_path, &repo_name, &build_manifest_path).await?,
+        } => {
+            build_cmd(
+                base_path,
+                &repo_name,
+                &build_manifest_path,
+                chunk_store_path,
+            )
+            .await?;
+        }
 
         Command::Install { repo_name, package } => {
-            install_cmd(base_path, repo_name, &package).await?;
+            install_cmd(base_path, repo_name, chunk_store_path, &package).await?;
         }
 
         Command::Remove { repo_name, package } => remove_cmd(base_path, repo_name, &package)?,
@@ -42,16 +51,26 @@ pub async fn main_commands(
         Command::Bundle { command } => bundle_commands(base_path, command)?,
 
         #[cfg(feature = "network")]
-        Command::Update => update_cmd(base_path, quicklaunch_path).await?,
+        Command::Update => update_cmd(base_path, quicklaunch_path, chunk_store_path).await?,
 
         Command::Run {
             repo_name,
             package,
             entrypoint,
             args,
-        } => run_cmd(base_path, repo_name, package, entrypoint, args).await?,
+        } => {
+            run_cmd(
+                base_path,
+                repo_name,
+                chunk_store_path,
+                package,
+                entrypoint,
+                args,
+            )
+            .await?;
+        }
 
-        Command::VerifyChunks { repo_name } => verify_cmd(base_path, &repo_name)?,
+        Command::VerifyChunks { repo_name } => verify_cmd(base_path, &repo_name, chunk_store_path)?,
     }
 
     Ok(())

--- a/src/commands/repo.rs
+++ b/src/commands/repo.rs
@@ -9,7 +9,7 @@ use crate::{
     utils::resolve_repo,
 };
 
-pub async fn repo_commands(path: &Path, command: RepoCommands) -> Result<()> {
+pub async fn repo_commands(path: &Path, chunks_path: &Path, command: RepoCommands) -> Result<()> {
     match command {
         RepoCommands::Create { repo_name } => repo::create(&path.join(&repo_name), None)?,
 

--- a/src/commands/repo.rs
+++ b/src/commands/repo.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use comfy_table::Table;
-use std::{fs, path::Path};
+use std::{fs, os::unix::fs::symlink, path::Path};
 
 use crate::{
     RepoCommands,
@@ -9,9 +9,18 @@ use crate::{
     utils::resolve_repo,
 };
 
-pub async fn repo_commands(path: &Path, chunks_path: &Path, command: RepoCommands) -> Result<()> {
+pub async fn repo_commands(
+    path: &Path,
+    chunk_store_path: &Path,
+    command: RepoCommands,
+) -> Result<()> {
     match command {
-        RepoCommands::Create { repo_name } => repo::create(&path.join(&repo_name), None)?,
+        RepoCommands::Create { repo_name } => {
+            let repo_path = &path.join(&repo_name);
+
+            repo::create(repo_path, None)?;
+            symlink(Path::new("../../chunks"), repo_path.join("chunks"))?;
+        }
 
         RepoCommands::List => {
             let mut table = Table::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,37 +21,66 @@ pub fn get_config_dir() -> Result<PathBuf> {
     Ok(config_dir)
 }
 
-/// Gets the default/main USER repositorys directory
+/// Gets the user repos directory
 ///
 /// # Errors
 ///
 /// - No valid home directory path could be retrieved from the operating system.
-/// - Reposiorys dir could not be created
-pub fn get_repos_dir() -> Result<PathBuf> {
-    // Locate XDG data directory
-    let base_dirs = BaseDirs::new().context("Could not find user directories")?;
-    let repos_dir: PathBuf = base_dirs.data_dir().join("flint");
+/// - Repositorys dir could not be created
+pub fn get_user_repos_dir() -> Result<PathBuf> {
+    let repos_dir = get_user_data_dir()?.join("repos");
 
-    if !&repos_dir.exists() {
+    if !repos_dir.exists() {
         fs::create_dir_all(&repos_dir)?;
     }
 
     Ok(repos_dir)
 }
 
-/// Gets the main quicklaunch directory
+/// Gets the system repos directory
+///
+/// # Errors
+///
+/// - Repositorys dir could not be created
+pub fn get_system_repos_dir() -> Result<PathBuf> {
+    let repos_dir = get_system_data_dir().join("repos");
+
+    if !repos_dir.exists() {
+        fs::create_dir_all(&repos_dir)
+            .with_context(|| "Could not create system data dir. Try sudo?")?;
+    }
+
+    Ok(repos_dir)
+}
+
+/// Gets the system-wide quicklaunch path
+///
+/// # Errors
+///
+/// - Quicklaunch dir could not be created
+pub fn get_system_quicklaunch_dir() -> Result<PathBuf> {
+    let quicklaunch_dir = get_system_data_dir().join("quicklaunch");
+
+    if !quicklaunch_dir.exists() {
+        fs::create_dir_all(&quicklaunch_dir)
+            .with_context(|| "Could not create quicklaunch dir. Try sudo?")?;
+    }
+
+    Ok(quicklaunch_dir)
+}
+
+/// Gets the users quicklaunch directory
 ///
 /// # Errors
 ///
 /// - No valid home directory path could be retrieved from the operating system.
 /// - Quicklaunch dir could not be created
-pub fn get_quicklaunch_dir() -> Result<PathBuf> {
-    // Locate XDG data directory
-    let base_dirs = BaseDirs::new().context("Could not find user directories")?;
-    let quicklaunch_dir: PathBuf = base_dirs.data_dir().join("flint-quicklaunch");
+pub fn get_user_quicklaunch_dir() -> Result<PathBuf> {
+    let quicklaunch_dir = get_user_data_dir()?.join("quicklaunch");
 
-    if !&quicklaunch_dir.exists() {
-        fs::create_dir_all(&quicklaunch_dir)?;
+    if !quicklaunch_dir.exists() {
+        fs::create_dir_all(&quicklaunch_dir)
+            .with_context(|| "Could not create quicklaunch dir. Try sudo?")?;
     }
 
     Ok(quicklaunch_dir)
@@ -77,7 +106,7 @@ pub fn get_build_cache_dir() -> Result<PathBuf> {
 
 #[must_use]
 /// Gets the SYSTEM-WIDE Repositorys path
-pub fn system_data_dir() -> PathBuf {
+fn get_system_data_dir() -> PathBuf {
     #[cfg(target_os = "linux")]
     {
         PathBuf::from("/var/lib/flint")
@@ -94,21 +123,19 @@ pub fn system_data_dir() -> PathBuf {
     }
 }
 
-#[must_use]
-/// Gets the SYSTEM-WIDE quicklaunch path
-pub fn system_quicklaunch_dir() -> PathBuf {
-    #[cfg(target_os = "linux")]
-    {
-        PathBuf::from("/var/lib/flint-quicklaunch")
+/// Gets the user data directory
+///
+/// # Errors
+///
+/// - No valid home directory path could be retrieved from the operating system.
+fn get_user_data_dir() -> Result<PathBuf> {
+    // Locate XDG data directory
+    let base_dirs = BaseDirs::new().context("Could not find user directories")?;
+    let data_dir: PathBuf = base_dirs.data_dir().join("flint");
+
+    if !&data_dir.exists() {
+        fs::create_dir_all(&data_dir)?;
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        PathBuf::from("/Library/Application Support/flint-quicklaunch")
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        PathBuf::from(r"C:\ProgramData\Flint-quicklaunch")
-    }
+    Ok(data_dir)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,38 @@ pub fn get_system_repos_dir() -> Result<PathBuf> {
     Ok(repos_dir)
 }
 
+/// Gets the user chunks directory
+///
+/// # Errors
+///
+/// - No valid home directory path could be retrieved from the operating system.
+/// - Chunks dir could not be created
+pub fn get_user_chunks_dir() -> Result<PathBuf> {
+    let chunks_dir = get_user_data_dir()?.join("chunks");
+
+    if !chunks_dir.exists() {
+        fs::create_dir_all(&chunks_dir)?;
+    }
+
+    Ok(chunks_dir)
+}
+
+/// Gets the system chunks directory
+///
+/// # Errors
+///
+/// - Chunks dir could not be created
+pub fn get_system_chunks_dir() -> Result<PathBuf> {
+    let chunks_dir = get_system_data_dir().join("chunks");
+
+    if !chunks_dir.exists() {
+        fs::create_dir_all(&chunks_dir)
+            .with_context(|| "Could not create system data dir. Try sudo?")?;
+    }
+
+    Ok(chunks_dir)
+}
+
 /// Gets the system-wide quicklaunch path
 ///
 /// # Errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use std::{env::var_os, path::PathBuf};
 
 use crate::{commands::main_commands, log::add_to_path_notice};
 use flintpkg::config::{
-    get_quicklaunch_dir, get_repos_dir, system_data_dir, system_quicklaunch_dir,
+    get_system_quicklaunch_dir, get_system_repos_dir, get_user_quicklaunch_dir, get_user_repos_dir,
 };
 
 /// Simple program to greet a person
@@ -157,15 +157,15 @@ async fn main() -> Result<()> {
     };
 
     let base_path = &if scope == Scope::User {
-        get_repos_dir()?
+        get_user_repos_dir()?
     } else {
-        system_data_dir()
+        get_system_repos_dir()?
     };
 
     let quicklaunch_path = &if scope == Scope::User {
-        get_quicklaunch_dir()?
+        get_user_quicklaunch_dir()?
     } else {
-        system_quicklaunch_dir()
+        get_system_quicklaunch_dir()?
     };
 
     main_commands(base_path, quicklaunch_path, args.command).await?;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -131,7 +131,7 @@ mod tests {
         fs::write(temp_tree.path().join("dir/file2"), "content2")?;
         let chunks = save_tree(
             temp_tree.path(),
-            &repo_path.join("chunks"),
+            chunks_path,
             crate::chunks::HashKind::Blake3,
         )?;
 

--- a/tests/full_workflow.rs
+++ b/tests/full_workflow.rs
@@ -12,13 +12,15 @@ use flintpkg::{
 async fn full_workflow_test() -> Result<()> {
     let repo_dir = TempDir::new()?;
     let repo_path = repo_dir.path();
+    let chunks_dir = TempDir::new()?;
+    let chunks_path = chunks_dir.path();
 
     repo::create(repo_path, None)?;
 
     let build_manifest_path = Path::new("build_manifest.yml");
-    build(build_manifest_path, repo_path, None).await?;
+    build(build_manifest_path, repo_path, None, chunks_path).await?;
 
-    install(repo_path, "example").await?;
+    install(repo_path, "example", chunks_path).await?;
 
     let manifest = get_installed_package(repo_path, "example")?;
 


### PR DESCRIPTION
Change the storage format, so all chunks are shared between Repositories.
This impacts both system repositories and user repositories

### Impacted User Repositories
~/.local/share/flint/* -> ~/.local/share/flint/repos/*
~/.local/share/flint-quicklaunch -> ~/.local/share/flint/quicklaunch
~/.local/share/flint/*/chunks -> ~/.local/share/flint/chunks

### Impacted System Repositories
/var/lib/flint/* -> /var/lib/flint/repos/*
/var/lib/flint-quicklaunch -> /var/lib/flint/quicklaunch
/var/lib/flint/*/chunks -> /var/lib/flint/chunks