### PR TITLE
Feature: prevent rebuilding

### DIFF
--- a/src/build/hash.rs
+++ b/src/build/hash.rs
@@ -56,3 +56,48 @@ pub fn calc_build_hash(build_manifest_path: &Path, repo_path: &Path) -> Result<S
 
     Ok(hash.finalize().to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use temp_dir::TempDir;
+
+    use super::*;
+    use crate::repo::{Metadata, create_repo};
+
+    #[test]
+    fn test_build_hash_stability() {
+        let manifest = BuildManifest {
+            id: "test_package".into(),
+            aliases: Vec::new(),
+            metadata: Metadata {
+                description: None,
+                homepage_url: None,
+                title: None,
+                version: None,
+                license: None,
+            },
+            commands: Vec::new(),
+            directory: PathBuf::from("."),
+            edition: "2025".into(),
+            build_script: None,
+            post_script: None,
+            sources: None,
+            include: None,
+            sdks: None,
+            env: None,
+        };
+
+        let repo = TempDir::new().unwrap();
+        create_repo(repo.path(), None).unwrap();
+
+        let manifest_path = repo.path().join("build_manifest.yml");
+
+        fs::write(&manifest_path, serde_yaml::to_string(&manifest).unwrap()).unwrap();
+
+        let known_hash = "680cec2b6b847e76d733fb435214b18ec2108e25b4dfc54695f5daa1e987ec8d";
+        let calc_hash = calc_build_hash(&manifest_path, repo.path()).unwrap();
+
+        assert_eq!(known_hash, calc_hash);
+    }
+}

--- a/src/build/hash.rs
+++ b/src/build/hash.rs
@@ -1,0 +1,58 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use super::BuildManifest;
+use crate::repo::{get_package, read_manifest};
+
+/// Get the `build_hash` of a `build_manifest`
+/// Requires all dependencies to be built and in the Repository beforehand.
+///
+/// # Errors
+///
+/// - Scripts do not exist
+/// - Invalid build manifest
+pub fn calc_build_hash(build_manifest_path: &Path, repo_path: &Path) -> Result<String> {
+    let build_manifest_path = build_manifest_path.canonicalize().with_context(
+        || "could not canoncicalize build manifest path. Does the build manifest exist?",
+    )?;
+    let build_manifest_raw = fs::read_to_string(build_manifest_path)?;
+    let build_manifest: BuildManifest = serde_yaml::from_str(&build_manifest_raw)?;
+
+    let repo_manifest = read_manifest(repo_path)?;
+
+    let mut hash = blake3::Hasher::new();
+
+    hash.write_all(build_manifest_raw.as_bytes())?;
+
+    // Hash the `includes`
+    if let Some(deps) = build_manifest.include {
+        for dep in deps {
+            let package = get_package(&repo_manifest, &dep)?;
+            hash.write_all(package.build_hash.as_bytes())?;
+        }
+    }
+
+    // Hash the `sdks`
+    if let Some(deps) = build_manifest.sdks {
+        for dep in deps {
+            let package = get_package(&repo_manifest, &dep)?;
+            hash.write_all(package.build_hash.as_bytes())?;
+        }
+    }
+
+    // Hash the `build_script`
+    if let Some(build_script) = build_manifest.build_script {
+        let script = fs::read_to_string(build_script)?;
+        hash.write_all(script.as_bytes())?;
+    }
+
+    // Hash the `post_script`
+    if let Some(post_script) = build_manifest.post_script {
+        let script = fs::read_to_string(post_script)?;
+        hash.write_all(script.as_bytes())?;
+    }
+
+    Ok(hash.finalize().to_string())
+}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -4,7 +4,7 @@ mod sources;
 
 use anyhow::{Context, Result, bail};
 use std::{
-    collections::BTreeMap,
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
     process::Command,
@@ -18,7 +18,7 @@ use crate::{
 use hash::calc_build_hash;
 use sources::get_sources;
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, Hash)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 struct BuildManifest {
     /// ID of this package, the main alias
     id: String,
@@ -46,11 +46,10 @@ struct BuildManifest {
     /// Useful for SDKs.
     sdks: Option<Vec<String>>,
     /// RUNTIME environment variables
-    /// This is a `BTreeMap` due to `HashMap` not having the `hash` trait.
-    env: Option<BTreeMap<String, String>>,
+    env: Option<HashMap<String, String>>,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, Hash)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 struct Source {
     /// Should either be git, tar or local
     kind: String,
@@ -199,7 +198,7 @@ fn include_all(
     build_dir: &Path,
     repo_path: &Path,
     chunk_store_path: &Path,
-    envs: &mut BTreeMap<String, String>,
+    envs: &mut HashMap<String, String>,
 ) -> Result<()> {
     for dependency in packages {
         let result = include(
@@ -224,7 +223,7 @@ fn include(
     path_to_include_at: &Path,
     repo_path: &Path,
     chunk_store_path: &Path,
-) -> Result<BTreeMap<String, String>> {
+) -> Result<HashMap<String, String>> {
     let dependency_build_manifest_path = search_path.join(dependency);
     let dependency_build_manifest: BuildManifest =
         serde_yaml::from_str(&fs::read_to_string(dependency_build_manifest_path)?)?;

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -173,6 +173,8 @@ pub async fn build(
         metadata: build_manifest.metadata,
         chunks: included_chunks,
         env: None,
+        // TODO!
+        build_hash: "TODO".to_string(),
     };
 
     if !envs.is_empty() {

--- a/src/commands/main.rs
+++ b/src/commands/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use flintpkg::{
-    build::build,
+    build::{build, force_build},
     chunks::{utils::clean_unused, verify_all_chunks},
     repo::{
         PackageManifest, get_package, read_manifest,
@@ -21,10 +21,15 @@ pub async fn build_cmd(
     repo_name: &str,
     build_manifest_path: &Path,
     chunk_store_path: &Path,
+    force: bool,
 ) -> Result<()> {
     let repo_path = resolve_repo(base_path, repo_name)?;
 
-    build(build_manifest_path, &repo_path, None, chunk_store_path).await?;
+    if force {
+        force_build(build_manifest_path, &repo_path, None, chunk_store_path).await?;
+    } else {
+        build(build_manifest_path, &repo_path, None, chunk_store_path).await?;
+    }
 
     clean_unused(base_path, chunk_store_path)?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -32,12 +32,14 @@ pub async fn main_commands(
         Command::Build {
             build_manifest_path,
             repo_name,
+            force,
         } => {
             build_cmd(
                 base_path,
                 &repo_name,
                 &build_manifest_path,
                 chunk_store_path,
+                force,
             )
             .await?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ enum Command {
     Build {
         build_manifest_path: PathBuf,
         repo_name: String,
+        #[arg(long, short)]
+        force: bool,
     },
     /// Install a package
     Install {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -239,6 +239,7 @@ mod tests {
                 license: None,
             },
             env: None,
+            build_hash: "Example Build Hash".to_string(),
         };
 
         insert_package(&package_manifest, repo_path, Some(repo_path))?;

--- a/src/repo/types.rs
+++ b/src/repo/types.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::chunks::{Chunk, HashKind};
 
@@ -20,13 +20,13 @@ pub struct PackageManifest {
     pub chunks: Vec<Chunk>,
     pub commands: Vec<PathBuf>,
     /// Runtime environment variables
-    pub env: Option<BTreeMap<String, String>>,
+    pub env: Option<HashMap<String, String>>,
     #[serde(default = "build_hash_default")]
     pub build_hash: String,
 }
 
 /// All of these are user visible, and should carry no actual weight.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Metadata {
     pub title: Option<String>,
     pub description: Option<String>,

--- a/src/repo/types.rs
+++ b/src/repo/types.rs
@@ -21,6 +21,8 @@ pub struct PackageManifest {
     pub commands: Vec<PathBuf>,
     /// Runtime environment variables
     pub env: Option<BTreeMap<String, String>>,
+    #[serde(default = "build_hash_default")]
+    pub build_hash: String,
 }
 
 /// All of these are user visible, and should carry no actual weight.
@@ -33,4 +35,8 @@ pub struct Metadata {
     pub version: Option<String>,
     /// SPDX Identifier
     pub license: Option<String>,
+}
+
+fn build_hash_default() -> String {
+    "uninitialized".to_string()
 }

--- a/src/repo/types.rs
+++ b/src/repo/types.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::chunks::{Chunk, HashKind};
 
@@ -20,11 +20,11 @@ pub struct PackageManifest {
     pub chunks: Vec<Chunk>,
     pub commands: Vec<PathBuf>,
     /// Runtime environment variables
-    pub env: Option<HashMap<String, String>>,
+    pub env: Option<BTreeMap<String, String>>,
 }
 
 /// All of these are user visible, and should carry no actual weight.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Metadata {
     pub title: Option<String>,
     pub description: Option<String>,

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,7 +2,7 @@ pub mod quicklaunch;
 
 use anyhow::{Context, Result, bail};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     ffi::OsStr,
     path::{Path, PathBuf},
     process::{Command, ExitStatus},
@@ -44,7 +44,7 @@ pub fn start<S: AsRef<OsStr>>(
         let entrypoint = entrypoint.to_string_lossy();
         let entrypoint: &str = entrypoint.trim_start_matches('/');
 
-        let mut envs: HashMap<String, String> = package_manifest.env.unwrap_or_default();
+        let mut envs: BTreeMap<String, String> = package_manifest.env.unwrap_or_default();
 
         // I hate I have to do this.
         let keys_to_update: Vec<String> = envs

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -113,7 +113,7 @@ pub async fn install_package(
 mod tests {
     use super::*;
     use crate::chunks::save_tree;
-    use crate::repo::{Metadata, PackageManifest, create_repo, insert_package};
+    use crate::repo::{Metadata, create_repo, insert_package};
     use std::fs;
     use temp_dir::TempDir;
 
@@ -150,6 +150,8 @@ mod tests {
             chunks,
             commands: Vec::new(),
             env: None,
+            // TODO!
+            build_hash: "TODO".to_string(),
         };
 
         // Insert package

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,7 +2,7 @@ pub mod quicklaunch;
 
 use anyhow::{Context, Result, bail};
 use std::{
-    collections::BTreeMap,
+    collections::HashMap,
     ffi::OsStr,
     path::{Path, PathBuf},
     process::{Command, ExitStatus},
@@ -44,7 +44,7 @@ pub fn start<S: AsRef<OsStr>>(
         let entrypoint = entrypoint.to_string_lossy();
         let entrypoint: &str = entrypoint.trim_start_matches('/');
 
-        let mut envs: BTreeMap<String, String> = package_manifest.env.unwrap_or_default();
+        let mut envs: HashMap<String, String> = package_manifest.env.unwrap_or_default();
 
         // I hate I have to do this.
         let keys_to_update: Vec<String> = envs


### PR DESCRIPTION
This adds a `build_hash` property to keep track of whether a package needs to actually be rebuilt.

Since it often doesn't keep track of sources (local non-git specifically), there is an optional `--force` flag to skip the check and force a rebuild.